### PR TITLE
Added medium-based artwork search functionality

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { FullTextSearchTool } from './tools/FullTextSearchTool';
 import { GetArtworkByArtistTool } from './tools/GetArtworkByArtistTool';
 import { GetArtworkByIdTool } from './tools/GetArtworkByIdTool';
 import { SearchByTitleTool } from './tools/SearchByTitleTool';
+import { SearchByMediumTool } from './tools/SearchByMediumTool';
 
 class ArticServer {
   private server: McpServer;
@@ -21,6 +22,7 @@ class ArticServer {
   private fullTextSearchTool: FullTextSearchTool;
   private artistSearchTool: ArtistSearchTool;
   private getArtworkByArtistTool: GetArtworkByArtistTool;
+  private searchByMediumTool: SearchByMediumTool;
   private listResources: ListResources;
   private readResources: ReadResources;
 
@@ -43,6 +45,7 @@ class ArticServer {
     this.fullTextSearchTool = new FullTextSearchTool();
     this.artistSearchTool = new ArtistSearchTool();
     this.getArtworkByArtistTool = new GetArtworkByArtistTool();
+    this.searchByMediumTool = new SearchByMediumTool();
     this.listResources = new ListResources(this.getArtworkByIdTool);
     this.readResources = new ReadResources(this.getArtworkByIdTool);
     this.setupTools();
@@ -80,6 +83,12 @@ class ArticServer {
       this.getArtworkByArtistTool.description,
       this.getArtworkByArtistTool.inputSchema.shape,
       this.getArtworkByArtistTool.execute.bind(this.getArtworkByArtistTool),
+    );
+    this.server.tool(
+      this.searchByMediumTool.name,
+      this.searchByMediumTool.description,
+      this.searchByMediumTool.inputSchema.shape,
+      this.searchByMediumTool.execute.bind(this.searchByMediumTool),
     );
   }
 

--- a/src/tools/SearchByMediumTool.ts
+++ b/src/tools/SearchByMediumTool.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+import { artworkSearchResponseSchema } from '../schemas/schemas';
+import { BaseTool } from './BaseTool';
+
+const mediumSearchSchema = z.object({
+  medium: z
+    .string()
+    .describe(
+      'The medium to search for (e.g., "oil on canvas", "acrylic on panel", "watercolor on paper").',
+    ),
+  limit: z
+    .number()
+    .optional()
+    .default(10)
+    .describe('The number of resources to return per page.'),
+  page: z
+    .number()
+    .optional()
+    .default(1)
+    .describe('The page of results to return. Used for pagination.'),
+});
+
+export class SearchByMediumTool extends BaseTool<
+  typeof mediumSearchSchema,
+  any
+> {
+  public readonly name: string = 'search-by-medium';
+  public readonly description: string =
+    'Search for artworks by medium in the Art Institute of Chicago. Pagination is supported with the page parameter';
+  public readonly inputSchema = mediumSearchSchema;
+
+  constructor() {
+    super();
+  }
+
+  public async executeCore(input: z.infer<typeof this.inputSchema>) {
+    const { medium, limit, page } = input;
+
+    const query = {
+      query: {
+        bool: {
+          should: [
+            { match_phrase: { medium_display: `${medium}` } },
+            { match: { medium_display: medium } },
+          ],
+          minimum_should_match: 1,
+        },
+      },
+    };
+
+    const url = new URL(`${this.apiBaseUrl}/artworks/search`);
+    url.searchParams.set('page', `${page}`);
+    url.searchParams.set('limit', `${limit}`);
+
+    const parsedData = await this.safeApiRequest(
+      url,
+      {
+        method: 'POST',
+        body: JSON.stringify(query),
+      },
+      artworkSearchResponseSchema,
+    );
+
+    // Attach pagination info to each artwork for formatting
+    parsedData.data.forEach((artwork: any) => {
+      artwork._pagination = parsedData.pagination;
+    });
+
+    return this.formatArtworkList(parsedData.data, medium);
+  }
+}


### PR DESCRIPTION
This PR adds a new search capability to the artic-mcp server, allowing users to search for artworks by their medium (e.g., "oil on canvas", "watercolor on paper", "acrylic on panel").
